### PR TITLE
Add the mechanism to trigger rewards distribution

### DIFF
--- a/pallets/halal-lending/src/lib.rs
+++ b/pallets/halal-lending/src/lib.rs
@@ -49,11 +49,11 @@ pub mod pallet {
 	#[pallet::getter(fn next_loan_id)]
 	pub type NextLoanId<T: Config> = StorageValue<_, T::LoanId, ValueQuery>;
 
-	/// Track original collateral amount (before rewards)
-	#[pallet::storage]
-	#[pallet::getter(fn original_collateral)]
-	pub type OriginalCollateral<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::LoanId, Balance, ValueQuery>;
+    /// Track rewards for each loan
+    #[pallet::storage]
+    #[pallet::getter(fn loan_rewards)]
+    pub type LoanRewards<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::LoanId, Balance, ValueQuery>;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -157,46 +157,7 @@ pub mod pallet {
 			Ok(current_ltv >= threshold)
 		}
 
-		fn do_claim_staking_rewards(loan_id: T::LoanId) -> Result<Balance, DispatchError> {
-			let loan = Loans::<T>::get(loan_id).ok_or(Error::<T>::LoanNotFound)?;
-
-			ensure!(loan.status == LoanStatus::Active, Error::<T>::LoanNotActive);
-
-			let current_balance =
-				T::MultiCurrency::free_balance(loan.collateral_vtoken, &Self::account_id());
-
-			let original_amount = OriginalCollateral::<T>::get(loan_id);
-
-			// Calculate rewards earned (current - original)
-			let rewards = current_balance.saturating_sub(original_amount);
-
-			// If no rewards, return early with 0 (don't fail)
-			if rewards == 0 {
-				return Ok(0);
-			}
-
-			let platform_share = T::StakingRewardFee::get().mul_floor(rewards);
-
-			T::MultiCurrency::transfer(
-				loan.collateral_vtoken,
-				&Self::account_id(),
-				&T::TreasuryAccount::get(),
-				platform_share,
-				ExistenceRequirement::AllowDeath,
-			)?;
-
-			// Emit event
-			Self::deposit_event(Event::RewardsClaimed {
-				loan_id,
-				total_rewards: rewards,
-				platform_share,
-				user_share: rewards.saturating_sub(platform_share),
-			});
-
-			Ok(platform_share)
-		}
 	}
-
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Create a new loan by depositing vToken collateral
@@ -233,6 +194,7 @@ pub mod pallet {
 				collateral_amount,
 				loan_currency,
 				loan_amount,
+                loan_reward: 0u128,
 				created_at: <frame_system::Pallet<T>>::block_number(),
 				status: LoanStatus::Active,
 			};
@@ -240,7 +202,7 @@ pub mod pallet {
 			// Store loan
 			Loans::<T>::insert(loan_id, loan);
 
-			OriginalCollateral::<T>::insert(loan_id, collateral_amount);
+            LoanRewards::<T>::insert(loan_id, 0u128);
 
 			UserLoans::<T>::try_mutate(&who, |loans| {
 				if let Some(ref mut loan_vec) = loans {
@@ -305,6 +267,9 @@ pub mod pallet {
 				ExistenceRequirement::AllowDeath,
 			)?;
 
+            // Claim rewards for loaner and loanee
+            Self::claim_loan_rewards(loan_id)?;
+
 			// Return collateral to user
 			T::MultiCurrency::transfer(
 				loan.collateral_vtoken,
@@ -325,15 +290,6 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Claim accumulated staking rewards from locked collateral
-		/// Can be called by anyone (typically automated)
-		#[pallet::call_index(2)]
-		#[pallet::weight(T::WeightInfo::claim_rewards())]
-		pub fn claim_staking_rewards(origin: OriginFor<T>, loan_id: T::LoanId) -> DispatchResult {
-			ensure_signed(origin)?; // Anyone can trigger
-			Self::do_claim_staking_rewards(loan_id)?;
-			Ok(())
-		}
 
 		/// Liquidate an under-collateralized loan
 		/// Anyone can call this to liquidate unhealthy loans
@@ -353,30 +309,8 @@ pub mod pallet {
 				Self::is_liquidatable(loan_id)?,
 				Error::<T>::LoanNotLiquidatable
 			);
-
-			// Try to claim staking rewards for platform (ignore if no rewards available)
-			let _ = Self::do_claim_staking_rewards(loan_id);
-
-			// Get original collateral amount
-			let original_amount = OriginalCollateral::<T>::get(loan_id);
-
-			// Get current vDOT balance (includes accumulated rewards of loanee)
-			let current_balance =
-				T::MultiCurrency::free_balance(loan.collateral_vtoken, &Self::account_id());
-
-			// Calculate rewards earned by loanee (current - original)
-			let loanee_rewards = current_balance.saturating_sub(original_amount);
-
-			if loanee_rewards > 0 {
-				// Transfer Loanee rewards to loanee
-				T::MultiCurrency::transfer(
-					loan.collateral_vtoken,
-					&Self::account_id(),
-					&loan.borrower,
-					loanee_rewards,
-					ExistenceRequirement::AllowDeath,
-				)?;
-			}
+            
+            Self::claim_loan_rewards(loan_id)?;
 
 			// Liquidator pays off the loan
 			T::MultiCurrency::transfer(
@@ -411,6 +345,26 @@ pub mod pallet {
 
 			Ok(())
 		}
+
+        #[pallet::call_index(2)]
+		#[pallet::weight(T::WeightInfo::distribute_cycle_rewards())]
+        pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> DispatchResult {
+            let mut total_asset_value = 0u128;
+            for (loan_id, loan) in Loans::<T>::iter() {
+                if loan.status == LoanStatus::Active {
+                    total_asset_value += loan.collateral_amount;
+                    total_asset_value += LoanRewards::<T>::get(loan_id); // Assuming loan.id is the correct field
+                }
+            }
+            for (loan_id, loan) in Loans::<T>::iter() {
+                if loan.status == LoanStatus::Active {
+                    let loanee_rewards = cycle_rewards * loan.collateral_amount / total_asset_value;
+                    LoanRewards::<T>::insert(loan_id, LoanRewards::<T>::get(loan_id) + loanee_rewards);
+                }
+            }
+            Ok(())
+			
+        }
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -439,6 +393,59 @@ pub mod pallet {
 				_ => None,
 			}
 		}
+
+        /// Claim accumulated staking rewards from locked collateral
+		/// Should be called internally at loan dissolving: (repayment or liquidation)
+		pub fn claim_loan_rewards(loan_id: T::LoanId) -> DispatchResult {
+			let loan = Loans::<T>::get(loan_id).ok_or(Error::<T>::LoanNotFound)?;
+
+			// Only claim from active loans
+			ensure!(loan.status == LoanStatus::Active, Error::<T>::LoanNotActive);
+
+            let rewards = LoanRewards::<T>::get(loan_id);
+
+			// If no rewards, return early with 0
+			if rewards == 0 {
+				return Ok(());
+			}
+
+			// Calculate platform's share (e.g., 30%)
+			let platform_share = T::StakingRewardFee::get().mul_floor(rewards);
+
+            // Calculate rewards earned by loanee (rewards - platform_share)
+            let loanee_rewards = rewards.saturating_sub(platform_share);
+
+            // Transfer Loanee rewards to loanee
+            T::MultiCurrency::transfer(
+                loan.collateral_vtoken,
+                &Self::account_id(),
+                &loan.borrower,
+                loanee_rewards,
+                ExistenceRequirement::AllowDeath,
+            )?;
+
+			// Transfer platform's share to treasury
+			T::MultiCurrency::transfer(
+				loan.collateral_vtoken,
+				&Self::account_id(),
+				&T::TreasuryAccount::get(),
+				platform_share,
+				ExistenceRequirement::AllowDeath,
+			)?;
+
+			// Emit event
+			Self::deposit_event(Event::RewardsClaimed {
+				loan_id,
+				total_rewards: rewards,
+				platform_share,
+				user_share: loanee_rewards,
+			});
+
+            // Nullify rewards of loan after distribution
+			LoanRewards::<T>::insert(loan_id, 0u128);
+			Ok(())
+		}
+
 	}
 
 	#[pallet::event]

--- a/pallets/halal-lending/src/lib.rs
+++ b/pallets/halal-lending/src/lib.rs
@@ -348,23 +348,35 @@ pub mod pallet {
 
         #[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::distribute_cycle_rewards())]
-        pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> DispatchResult {
-            let mut total_asset_value = 0u128;
-            for (loan_id, loan) in Loans::<T>::iter() {
-                if loan.status == LoanStatus::Active {
-                    total_asset_value += loan.collateral_amount;
-                    total_asset_value += LoanRewards::<T>::get(loan_id); // Assuming loan.id is the correct field
-                }
-            }
-            for (loan_id, loan) in Loans::<T>::iter() {
-                if loan.status == LoanStatus::Active {
-                    let loanee_rewards = cycle_rewards * loan.collateral_amount / total_asset_value;
-                    LoanRewards::<T>::insert(loan_id, LoanRewards::<T>::get(loan_id) + loanee_rewards);
-                }
-            }
-            Ok(())
-			
-        }
+pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> DispatchResult {
+			let active_loans: Vec<_> = Loans::<T>::iter()
+				.filter(|(_, loan)| loan.status == LoanStatus::Active)
+				.collect();
+
+			if active_loans.is_empty() {
+				return Ok(());
+			}
+
+			let total_asset_value: Balance = active_loans
+				.iter()
+				.map(|(loan_id, loan)| {
+					loan.collateral_amount
+						.saturating_add(LoanRewards::<T>::get(loan_id))
+				})
+				.sum();
+
+			for (loan_id, loan) in active_loans {
+				let loanee_rewards = cycle_rewards
+					.saturating_mul(loan.collateral_amount)
+					.saturating_div(total_asset_value);
+
+				LoanRewards::<T>::mutate(loan_id, |rewards| {
+					*rewards = rewards.saturating_add(loanee_rewards);
+				});
+			}
+
+			Ok(())
+		}
 	}
 
 	impl<T: Config> Pallet<T> {

--- a/pallets/halal-lending/src/lib.rs
+++ b/pallets/halal-lending/src/lib.rs
@@ -49,11 +49,11 @@ pub mod pallet {
 	#[pallet::getter(fn next_loan_id)]
 	pub type NextLoanId<T: Config> = StorageValue<_, T::LoanId, ValueQuery>;
 
-    /// Track rewards for each loan
-    #[pallet::storage]
-    #[pallet::getter(fn loan_rewards)]
-    pub type LoanRewards<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::LoanId, Balance, ValueQuery>;
+	/// Track rewards for each loan
+	#[pallet::storage]
+	#[pallet::getter(fn loan_rewards)]
+	pub type LoanRewards<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::LoanId, Balance, ValueQuery>;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
@@ -156,7 +156,6 @@ pub mod pallet {
 
 			Ok(current_ltv >= threshold)
 		}
-
 	}
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
@@ -194,7 +193,6 @@ pub mod pallet {
 				collateral_amount,
 				loan_currency,
 				loan_amount,
-                loan_reward: 0u128,
 				created_at: <frame_system::Pallet<T>>::block_number(),
 				status: LoanStatus::Active,
 			};
@@ -202,7 +200,7 @@ pub mod pallet {
 			// Store loan
 			Loans::<T>::insert(loan_id, loan);
 
-            LoanRewards::<T>::insert(loan_id, 0u128);
+			LoanRewards::<T>::insert(loan_id, 0u128);
 
 			UserLoans::<T>::try_mutate(&who, |loans| {
 				if let Some(ref mut loan_vec) = loans {
@@ -267,8 +265,8 @@ pub mod pallet {
 				ExistenceRequirement::AllowDeath,
 			)?;
 
-            // Claim rewards for loaner and loanee
-            Self::claim_loan_rewards(loan_id)?;
+			// Claim rewards for loaner and loanee
+			Self::claim_loan_rewards(loan_id)?;
 
 			// Return collateral to user
 			T::MultiCurrency::transfer(
@@ -290,7 +288,6 @@ pub mod pallet {
 			Ok(())
 		}
 
-
 		/// Liquidate an under-collateralized loan
 		/// Anyone can call this to liquidate unhealthy loans
 		#[pallet::call_index(3)]
@@ -309,8 +306,8 @@ pub mod pallet {
 				Self::is_liquidatable(loan_id)?,
 				Error::<T>::LoanNotLiquidatable
 			);
-            
-            Self::claim_loan_rewards(loan_id)?;
+
+			Self::claim_loan_rewards(loan_id)?;
 
 			// Liquidator pays off the loan
 			T::MultiCurrency::transfer(
@@ -346,9 +343,9 @@ pub mod pallet {
 			Ok(())
 		}
 
-        #[pallet::call_index(2)]
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::distribute_cycle_rewards())]
-pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> DispatchResult {
+		pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> DispatchResult {
 			let active_loans: Vec<_> = Loans::<T>::iter()
 				.filter(|(_, loan)| loan.status == LoanStatus::Active)
 				.collect();
@@ -357,6 +354,7 @@ pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> Disp
 				return Ok(());
 			}
 
+			let len_u32 = active_loans.len() as u32;
 			let total_asset_value: Balance = active_loans
 				.iter()
 				.map(|(loan_id, loan)| {
@@ -374,6 +372,13 @@ pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> Disp
 					*rewards = rewards.saturating_add(loanee_rewards);
 				});
 			}
+
+			// Emit event
+			Self::deposit_event(Event::CycleRewardsDistributed {
+				cycle_rewards,
+				total_asset_value,
+				n_active_loans: len_u32,
+			});
 
 			Ok(())
 		}
@@ -406,7 +411,7 @@ pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> Disp
 			}
 		}
 
-        /// Claim accumulated staking rewards from locked collateral
+		/// Claim accumulated staking rewards from locked collateral
 		/// Should be called internally at loan dissolving: (repayment or liquidation)
 		pub fn claim_loan_rewards(loan_id: T::LoanId) -> DispatchResult {
 			let loan = Loans::<T>::get(loan_id).ok_or(Error::<T>::LoanNotFound)?;
@@ -414,7 +419,7 @@ pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> Disp
 			// Only claim from active loans
 			ensure!(loan.status == LoanStatus::Active, Error::<T>::LoanNotActive);
 
-            let rewards = LoanRewards::<T>::get(loan_id);
+			let rewards = LoanRewards::<T>::get(loan_id);
 
 			// If no rewards, return early with 0
 			if rewards == 0 {
@@ -424,17 +429,17 @@ pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> Disp
 			// Calculate platform's share (e.g., 30%)
 			let platform_share = T::StakingRewardFee::get().mul_floor(rewards);
 
-            // Calculate rewards earned by loanee (rewards - platform_share)
-            let loanee_rewards = rewards.saturating_sub(platform_share);
+			// Calculate rewards earned by loanee (rewards - platform_share)
+			let loanee_rewards = rewards.saturating_sub(platform_share);
 
-            // Transfer Loanee rewards to loanee
-            T::MultiCurrency::transfer(
-                loan.collateral_vtoken,
-                &Self::account_id(),
-                &loan.borrower,
-                loanee_rewards,
-                ExistenceRequirement::AllowDeath,
-            )?;
+			// Transfer Loanee rewards to loanee
+			T::MultiCurrency::transfer(
+				loan.collateral_vtoken,
+				&Self::account_id(),
+				&loan.borrower,
+				loanee_rewards,
+				ExistenceRequirement::AllowDeath,
+			)?;
 
 			// Transfer platform's share to treasury
 			T::MultiCurrency::transfer(
@@ -453,11 +458,10 @@ pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> Disp
 				user_share: loanee_rewards,
 			});
 
-            // Nullify rewards of loan after distribution
+			// Nullify rewards of loan after distribution
 			LoanRewards::<T>::insert(loan_id, 0u128);
 			Ok(())
 		}
-
 	}
 
 	#[pallet::event]
@@ -485,7 +489,12 @@ pub fn distribute_cycle_rewards(_: OriginFor<T>, cycle_rewards: Balance) -> Disp
 			collateral_liquidated: Balance,
 			debt_covered: Balance,
 		},
-
+		/// Cycle rewards distributed [cycle_rewards, n_active_loans]
+		CycleRewardsDistributed {
+			cycle_rewards: Balance,
+			total_asset_value: Balance,
+			n_active_loans: u32,
+		},
 		/// Staking rewards claimed [loan_id, total_rewards, platform_share, user_share]
 		RewardsClaimed {
 			loan_id: T::LoanId,

--- a/pallets/halal-lending/src/tests.rs
+++ b/pallets/halal-lending/src/tests.rs
@@ -1,7 +1,7 @@
 // Tests for halal-lending pallet
 
 use crate::mock::*;
-use crate::pallet::{Error, Event, LoanStatus, Loans, NextLoanId};
+use crate::pallet::{Error, Event, LoanStatus, Loans, LoanRewards, NextLoanId};
 use frame_support::{assert_noop, assert_ok};
 use orml_traits::MultiCurrency;
 use sp_runtime::{FixedU128, Permill};
@@ -296,9 +296,9 @@ fn test_loan_not_found() {
 }
 
 #[test]
-fn test_claim_staking_rewards() {
-	new_test_ext().execute_with(|| {
-		// Create loan with 1,000 vDOT collateral
+fn test_distribute_cycle_rewards() {
+    new_test_ext().execute_with(|| {
+		// Alice creates first loan
 		assert_ok!(HalalLending::create_loan(
 			RuntimeOrigin::signed(ALICE),
 			MOCK_VTOKEN,
@@ -307,32 +307,69 @@ fn test_claim_staking_rewards() {
 			500
 		));
 
-		println!("\n=== SIMULATING STAKING REWARDS ===");
+		// Bob creates a loan
+		assert_ok!(HalalLending::create_loan(
+			RuntimeOrigin::signed(BOB),
+			MOCK_VTOKEN,
+			2_000,
+			MOCK_USDC,
+			1_000
+		));
 
-		// Simulate staking rewards by minting more vDOT to pallet
-		// In reality, vDOT balance grows automatically
-		assert_ok!(Tokens::deposit(
+		// Alice creates second loan
+		assert_ok!(HalalLending::create_loan(
+			RuntimeOrigin::signed(ALICE),
+			MOCK_VTOKEN,
+			500,
+			MOCK_USDC,
+			250
+		));
+
+		// Verify loan IDs incremented correctly
+		assert_eq!(NextLoanId::<Test>::get(), 3);
+
+		// Verify each loan
+		let loan0 = Loans::<Test>::get(0).unwrap();
+		assert_eq!(loan0.borrower, ALICE);
+		assert_eq!(loan0.loan_amount, 500);
+
+		let loan1 = Loans::<Test>::get(1).unwrap();
+		assert_eq!(loan1.borrower, BOB);
+		assert_eq!(loan1.loan_amount, 1_000);
+
+		let loan2 = Loans::<Test>::get(2).unwrap();
+		assert_eq!(loan2.borrower, ALICE);
+		assert_eq!(loan2.loan_amount, 250);
+
+        assert_ok!(Tokens::deposit(
 			MOCK_VTOKEN,
 			&HalalLending::account_id(),
-			150 // 15% rewards after 1 year
+			350 // simulate staking rewards
 		));
 
-		println!(
-			"Pallet vDOT balance before claim: {}",
-			Tokens::free_balance(MOCK_VTOKEN, &HalalLending::account_id())
-		);
-		println!(
-			"Treasury vDOT balance before claim: {}",
-			Tokens::free_balance(MOCK_VTOKEN, &TREASURY)
-		);
+        let _ = HalalLending::distribute_cycle_rewards(RuntimeOrigin::signed(ALICE), 350);
+        
+        assert_eq!(LoanRewards::<Test>::get(0), 100);
+        assert_eq!(LoanRewards::<Test>::get(1), 200);
+        assert_eq!(LoanRewards::<Test>::get(2), 50);
+        
+        let _ = HalalLending::claim_loan_rewards(0);
+        // Verify event
+		System::assert_has_event(RuntimeEvent::HalalLending(Event::RewardsClaimed {
+			loan_id: 0,
+			total_rewards: 100,
+			platform_share: 30,
+			user_share: 70,
+		}));
+        // Verify reward distribution, 30% of each reward
+		assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 30);
+        let _ = HalalLending::claim_loan_rewards(1);
+        assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 90);
+        let _ = HalalLending::claim_loan_rewards(2);
+        // 30% of total rewards
+        assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 105);
 
-		// Claim rewards (anyone can trigger)
-		assert_ok!(HalalLending::claim_staking_rewards(
-			RuntimeOrigin::signed(BOB), // Anyone can call
-			0                           // loan_id
-		));
-
-		println!("\n=== AFTER REWARD CLAIM ===");
+        println!("\n=== AFTER REWARD CLAIM ===");
 		println!(
 			"Pallet vDOT balance: {}",
 			Tokens::free_balance(MOCK_VTOKEN, &HalalLending::account_id())
@@ -342,31 +379,9 @@ fn test_claim_staking_rewards() {
 			Tokens::free_balance(MOCK_VTOKEN, &TREASURY)
 		);
 
-		// Verify reward distribution
-		// Total vDOT: 1,000 (initial) + 1,000 (collateral) + 150 (rewards) = 2,150
-		// Platform gets 30% of 150 = 45 vDOT... but wait, the claim_rewards logic uses current_balance - original
-		// current_balance = 2,150, original = 1,000, rewards = 1,150, platform_share = 30% of 1,150 = 345
-		assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 345);
-
-		// Pallet keeps: 2,150 - 345 = 1,805
-		assert_eq!(
-			Tokens::free_balance(MOCK_VTOKEN, &HalalLending::account_id()),
-			1_805
-		);
-
-		// Verify event
-		System::assert_has_event(RuntimeEvent::HalalLending(Event::RewardsClaimed {
-			loan_id: 0,
-			total_rewards: 1_150,
-			platform_share: 345,
-			user_share: 805,
-		}));
-
 		println!("\n✅ REVENUE COLLECTION SUCCESS:");
-		println!("   - Platform earned: 345 vDOT (30%)");
-		println!("   - User keeps: 805 vDOT (70%)");
-		println!("   - Total rewards: 1,150 vDOT");
-	});
+		println!("   - Platform earned: 105 vDOT (30%)");
+});
 }
 
 #[test]

--- a/pallets/halal-lending/src/tests.rs
+++ b/pallets/halal-lending/src/tests.rs
@@ -1,7 +1,7 @@
 // Tests for halal-lending pallet
 
 use crate::mock::*;
-use crate::pallet::{Error, Event, LoanStatus, Loans, LoanRewards, NextLoanId};
+use crate::pallet::{Error, Event, LoanRewards, LoanStatus, Loans, NextLoanId};
 use frame_support::{assert_noop, assert_ok};
 use orml_traits::MultiCurrency;
 use sp_runtime::{FixedU128, Permill};
@@ -297,7 +297,7 @@ fn test_loan_not_found() {
 
 #[test]
 fn test_distribute_cycle_rewards() {
-    new_test_ext().execute_with(|| {
+	new_test_ext().execute_with(|| {
 		// Alice creates first loan
 		assert_ok!(HalalLending::create_loan(
 			RuntimeOrigin::signed(ALICE),
@@ -341,35 +341,35 @@ fn test_distribute_cycle_rewards() {
 		assert_eq!(loan2.borrower, ALICE);
 		assert_eq!(loan2.loan_amount, 250);
 
-        assert_ok!(Tokens::deposit(
+		assert_ok!(Tokens::deposit(
 			MOCK_VTOKEN,
 			&HalalLending::account_id(),
 			350 // simulate staking rewards
 		));
 
-        let _ = HalalLending::distribute_cycle_rewards(RuntimeOrigin::signed(ALICE), 350);
-        
-        assert_eq!(LoanRewards::<Test>::get(0), 100);
-        assert_eq!(LoanRewards::<Test>::get(1), 200);
-        assert_eq!(LoanRewards::<Test>::get(2), 50);
-        
-        let _ = HalalLending::claim_loan_rewards(0);
-        // Verify event
+		let _ = HalalLending::distribute_cycle_rewards(RuntimeOrigin::signed(ALICE), 350);
+
+		assert_eq!(LoanRewards::<Test>::get(0), 100);
+		assert_eq!(LoanRewards::<Test>::get(1), 200);
+		assert_eq!(LoanRewards::<Test>::get(2), 50);
+
+		let _ = HalalLending::claim_loan_rewards(0);
+		// Verify event
 		System::assert_has_event(RuntimeEvent::HalalLending(Event::RewardsClaimed {
 			loan_id: 0,
 			total_rewards: 100,
 			platform_share: 30,
 			user_share: 70,
 		}));
-        // Verify reward distribution, 30% of each reward
+		// Verify reward distribution, 30% of each reward
 		assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 30);
-        let _ = HalalLending::claim_loan_rewards(1);
-        assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 90);
-        let _ = HalalLending::claim_loan_rewards(2);
-        // 30% of total rewards
-        assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 105);
+		let _ = HalalLending::claim_loan_rewards(1);
+		assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 90);
+		let _ = HalalLending::claim_loan_rewards(2);
+		// 30% of total rewards
+		assert_eq!(Tokens::free_balance(MOCK_VTOKEN, &TREASURY), 105);
 
-        println!("\n=== AFTER REWARD CLAIM ===");
+		println!("\n=== AFTER REWARD CLAIM ===");
 		println!(
 			"Pallet vDOT balance: {}",
 			Tokens::free_balance(MOCK_VTOKEN, &HalalLending::account_id())
@@ -381,7 +381,7 @@ fn test_distribute_cycle_rewards() {
 
 		println!("\n✅ REVENUE COLLECTION SUCCESS:");
 		println!("   - Platform earned: 105 vDOT (30%)");
-});
+	});
 }
 
 #[test]

--- a/pallets/halal-lending/src/types.rs
+++ b/pallets/halal-lending/src/types.rs
@@ -22,7 +22,6 @@ pub struct LoanPosition<AccountId, BlockNumber> {
 	pub collateral_amount: Balance,
 	pub loan_currency: CurrencyId,
 	pub loan_amount: Balance,
-    pub loan_reward: Balance,
 	pub created_at: BlockNumber,
 	pub status: LoanStatus,
 }

--- a/pallets/halal-lending/src/types.rs
+++ b/pallets/halal-lending/src/types.rs
@@ -22,6 +22,7 @@ pub struct LoanPosition<AccountId, BlockNumber> {
 	pub collateral_amount: Balance,
 	pub loan_currency: CurrencyId,
 	pub loan_amount: Balance,
+    pub loan_reward: Balance,
 	pub created_at: BlockNumber,
 	pub status: LoanStatus,
 }
@@ -38,7 +39,7 @@ pub trait PriceProvider<CurrencyId> {
 pub trait WeightInfo {
 	fn create_loan() -> Weight;
 	fn repay_loan() -> Weight;
-	fn claim_rewards() -> Weight;
+	fn distribute_cycle_rewards() -> Weight;
 	fn liquidate_loan() -> Weight;
 }
 
@@ -50,7 +51,7 @@ impl WeightInfo for () {
 	fn repay_loan() -> Weight {
 		Weight::from_parts(10_000, 0)
 	}
-	fn claim_rewards() -> Weight {
+	fn distribute_cycle_rewards() -> Weight {
 		Weight::from_parts(10_000, 0)
 	}
 	fn liquidate_loan() -> Weight {


### PR DESCRIPTION
Distribute rewards on active loans each cycle, and claim rewards at least one time in the loan's lifetime (currently only once at loan dissolving)